### PR TITLE
docs: add a prepare-docs.sh to pull markdown files from totalcross-docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Prepare documentation markdown files
+        run: ./prepare-docs
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 .cache/
 public
 
+# markdowns from totalcross-docs
+src/docs/md/**
+
 # dependencies
 node_modules

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 ```sh
 yarn # npm i
 ```
-
+### Pull markdown files from totalcross-docs
+```sh
+./prepare-docs
+```
 ## Start developing
 
 ```sh

--- a/prepare-docs.sh
+++ b/prepare-docs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+WORKDIR=$(cd $BASEDIR; pwd)
+#wipe src/docs/md
+rm -rf "${WORKDIR}/src/docs/md"
+# update t
+git clone https://github.com/TotalCross/docs --depth=1 --branch=master "${WORKDIR}/src/docs/md"


### PR DESCRIPTION
this change adds a shell script, prepare-docs.sh, to pull markdown files from
branch master of totalcross-docs repo to inside the folder src/docs/md. The
destiny folder is ignored by git as described in the file .gitignore.

execute the following command to pull markdown files from the repository totalcross-docs to `src/docs/md`
```
./prepare-docs.sh
```