### PR TITLE
Fix 404 link on website home

### DIFF
--- a/src/components/reasons-home.js
+++ b/src/components/reasons-home.js
@@ -184,7 +184,7 @@ function Reasons() {
           <TCButton
             color="black"
             text="Check our Samples"
-            path="https://github.com/TotalCross/totalcross-embedded-samples"
+            path="https://github.com/TotalCross/embedded-samples"
           />
         </div>
       </div>


### PR DESCRIPTION
It looks like the `embedded-samples` repository got renamed, and the link on the home linked to the old one. This fixes that!