### PR TITLE
fix(images): correct HiDPI responsive image rendering

### DIFF
--- a/.agent/evidence/hidpi-responsive-image-correction.md
+++ b/.agent/evidence/hidpi-responsive-image-correction.md
@@ -1,0 +1,72 @@
+<!--
+SPDX-FileCopyrightText: 2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: MIT
+-->
+
+# HiDPI responsive image correction evidence
+
+## 2026-08-11T01:29:50Z — H1 rendering geometry
+
+- Revision: `978865163247cf88f74d8c5602591819ff8b77f5`.
+- Sources: `home_homeapp` is 1024×600 (blob `911d7b8`, ratio 128:75);
+  `home_tecdet` is 3366×2092 (blob `9942852`, ratio 1683:1046).
+- Existing variants: `home_homeapp` has 480×281, 768×450, and 1024×600
+  AVIF/WebP files; `home_tecdet` has 360×224, 600×373, and 900×559
+  AVIF/WebP files. Integer rounding accounts for the one-pixel height differences.
+- Existing markup retains AVIF preference, WebP fallback, alt text, and lazy
+  loading. Tecdet also emits an unnecessary 3366×2092 fallback WebP outside its
+  responsive candidate list.
+- Geometry: at a 1440 CSS px viewport, the 1440 px container with 80 px gutters
+  and an 86.4 px two-column gap yields about 596.8 CSS px per column, requiring
+  about 1193.6 physical px at DPR 2.
+- Narrow source search: all historical `home_homeapp` blobs are 1024×600 or
+  smaller (1024×600, 820×480, 410×240, and 205×120). No genuine higher-resolution
+  repository source exists, so source replacement/upscaling is rejected.
+- Limitation: visual validation remains deferred until the single final production
+  build after implementation.
+
+## 2026-08-11T01:33:00Z — H4 first-build visual finding
+
+- Commands: `npm run build`, generated-output inspection, `npm run assets:check`,
+  and headless Edge at 1440 CSS px with DPR 2.
+- Result: source candidates, AVIF/WebP delivery, and payload policy passed, but the
+  desktop screenshot exposed Tecdet vertical stretching. Generated files retained
+  the 1683:1046 source ratio, isolating the defect to the existing case-study CSS
+  width override without `height: auto`.
+- Action: add the narrow `.case-study > picture img { height: auto; }` safeguard and
+  perform one replacement final build/visual pass. The extra build is necessary
+  because the first visual pass found a concrete acceptance failure.
+
+## 2026-08-11T01:35:30Z — H4 final validation
+
+- Revision under validation: working tree based on `9788651`.
+- Commands: `git diff --check`; `npm run license:check` (5/5 compliant);
+  `npm run license:check:all` (175/175 compliant, 73 mapped); `npm run check`
+  (54 files, zero diagnostics); replacement-final `npm run build`; generated
+  markup/dimension assertions; `npm run assets:check`; and headless Edge captures.
+- Final candidates: Home Automation 480/768/1024 in AVIF and WebP, with a 512 CSS
+  px cap; Tecdet 480/768/1200/1600 in AVIF and WebP, with a 1600 px fallback.
+- Ratio proof: every generated width/height pair is within 0.5 px of its source
+  ratio after integer rounding; worst observed error is 0.415 px.
+- DPR proof: at 1440 CSS px the Tecdet `sizes` value caps at 600 px, so DPR 2
+  targets the exact 1200 px candidate. At 390 px the 350 px declared slot selects
+  480 px at DPR 1 or 768 px at DPR 2. Home Automation caps at 512 CSS px, so its
+  1024 px source is not exceeded at normal desktop DPR 2.
+- Payload: `assets:check` passes with zero failures and one unchanged unrelated
+  warning. The homepage fallback proxy is 1,713,535 bytes (1.63 MiB), down from
+  the prior 2,111,330-byte (2.01 MiB) evidence. The responsive Tecdet set grows by
+  100,669 bytes in generated output while eliminating the unused 605,226-byte
+  3366 px fallback; browser-selected mobile and DPR 1 candidates remain compact.
+- Visual: headless Edge at 1440 CSS px/DPR2 (2880 px capture) and 390 CSS px shows
+  both images at their original landscape ratios, the 512 px Home Automation cap,
+  unchanged content/order, and responsive mobile stacking. Temporary screenshots:
+  `/tmp/totalcross-hidpi.ZEK5v6/home-1440-dpr2-final.png` and
+  `/tmp/totalcross-hidpi.ZEK5v6/home-390-final.png`.
+- Limitation: no deployment or post-deployment capture was requested or performed.
+
+## 2026-08-11T01:38:00Z — H4 logical commits
+
+- `b9326e5` — `fix(images): correct homepage HiDPI rendering`.
+- `b6110f8` — `docs(agents): account for HiDPI image sizing`.
+- Status: implementation and reusable guidance recorded without unrelated files;
+  plan/state/evidence/editorial closure follows as its own documentation commit.

--- a/.agent/plans/hidpi-responsive-image-correction.md
+++ b/.agent/plans/hidpi-responsive-image-correction.md
@@ -1,0 +1,405 @@
+<!--
+SPDX-FileCopyrightText: 2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: MIT
+-->
+
+# Correct HiDPI responsive image rendering
+
+This ExecPlan follows `AGENTS.md` and `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+Correct the two remaining visual regressions observed after the post-migration
+asset optimization:
+
+- `home_homeapp` appears soft/distorted on HiDPI displays because the largest
+  generated responsive variant is only 1024 px wide while the image can render
+  near 500–600 CSS px on desktop.
+- `home_tecdet` appears soft/distorted for the same reason, even though its source
+  image has enough intrinsic resolution to generate substantially larger variants.
+
+The goal is to preserve the current optimized payload while ensuring these images
+remain visually sharp at common desktop Retina/HiDPI device pixel ratios.
+
+This is a focused patch. Do not reopen the broader asset optimization work unless
+new evidence shows another image has the same defect.
+
+## Working Set and Resume Protocol
+
+Use these support paths if execution is interrupted:
+
+- `.agent/plans/hidpi-responsive-image-correction.md` — this ExecPlan.
+- `.agent/state/hidpi-responsive-image-correction.md` — first read on resume;
+  rewrite rather than append.
+- `.agent/evidence/hidpi-responsive-image-correction.md` — append concise
+  measurements and validation results.
+- `.agent/archive/hidpi-responsive-image-correction-history.md` — completed
+  implementation detail only if the active plan needs consolidation.
+- `.agent/reports/hidpi-responsive-image-correction-editorial.md` — optional
+  final factual report if repository policy requires one for this patch.
+
+On resume, read the state file first, then only the relevant section of
+`src/pages/index.astro`, the asset optimization skill, and the exact source assets
+involved. Do not reread the completed migration or prior optimization ExecPlans.
+
+Before changing files, inspect:
+
+    git status --short
+    git rev-parse HEAD
+    git branch --show-current
+
+Preserve unrelated local changes.
+
+## Progress
+
+- [x] (2026-08-11T01:29:50Z) Confirmed source dimensions, historical
+      `home_homeapp` limits, current responsive variants, and normal desktop
+      rendering geometry; see `.agent/evidence/hidpi-responsive-image-correction.md`.
+- [x] (2026-08-11T01:29:50Z) Corrected Tecdet responsive candidates and fallback
+      dimensions, and constrained Home Automation to its real DPR 2 source budget.
+- [x] (2026-08-11T01:29:50Z) Updated asset-optimization guidance to account for
+      maximum CSS width, target DPR, and the prohibition on source upscaling.
+- [x] (2026-08-11T01:35:30Z) Passed license, Astro, production output,
+      aspect-ratio, asset-budget, and 1440/DPR2 plus 390 px visual validation;
+      see `.agent/evidence/hidpi-responsive-image-correction.md`.
+- [x] (2026-08-11T01:38:00Z) Recorded final evidence and created logical
+      Conventional Commits for implementation and reusable guidance; this plan's
+      support files close in the final documentation commit.
+
+## Current Architecture and Scope
+
+The homepage is implemented in:
+
+    src/pages/index.astro
+
+Both affected images are imported from:
+
+    src/assets/home_homeapp.png
+    src/assets/home_tecdet.png
+
+They are rendered through Astro `Picture`.
+
+Current relevant behavior is approximately:
+
+    home_homeapp:
+      widths = [480, 768, 1024]
+      sizes = "(max-width: 768px) 100vw, 50vw"
+
+    home_tecdet:
+      widths = [360, 600, 900]
+      sizes = "(max-width: 768px) 100vw, 50vw"
+
+The source dimensions observed during the prior audit were approximately:
+
+    home_homeapp: 1024 x 600
+    home_tecdet: 3366 x 2092
+
+The issue is not an aspect-ratio mismatch in the AVIF encoder. The generated
+variants preserve the original ratio. The problem is that the browser can render
+the images near 500–600 CSS pixels wide on desktop while a DPR 2 display ideally
+needs roughly 1000–1200 physical pixels.
+
+`home_tecdet` can safely generate larger variants from its high-resolution source.
+
+`home_homeapp` cannot gain real detail beyond 1024 source pixels. Do not upscale
+the source merely to satisfy a responsive-width list.
+
+Out of scope:
+
+- redesigning homepage sections;
+- changing image content;
+- replacing the current Astro image pipeline;
+- reworking unrelated assets;
+- broad performance-budget changes;
+- changing existing licensing/provenance classification.
+
+## Plan of Work
+
+### Milestone H1 — Confirm rendering geometry
+
+Goal: verify the exact relationship between source dimensions, generated variants,
+and rendered CSS width before changing responsive configuration.
+
+Inspect only the two source assets and the two corresponding `Picture` usages.
+
+Record:
+
+- source width and height;
+- aspect ratio;
+- current `widths`;
+- current `sizes`;
+- expected maximum desktop CSS width;
+- expected DPR 2 physical-pixel requirement;
+- generated AVIF/WebP dimensions from one production build.
+
+Do not run repeated builds during investigation. If the previous production
+artifact already provides sufficient evidence, reuse it.
+
+Acceptance:
+
+- confirm that both generated images preserve source aspect ratio;
+- confirm that `home_tecdet` is being capped below an appropriate HiDPI width;
+- confirm that `home_homeapp` source resolution itself is the limiting factor.
+
+No implementation changes are required in this milestone if existing evidence is
+already sufficient.
+
+### Milestone H2 — Correct Tecdet responsive variants
+
+Goal: allow the browser to select a sufficiently sharp Tecdet image on HiDPI
+desktop displays without forcing large downloads on smaller screens.
+
+Update the Tecdet `Picture` widths to include larger variants. Prefer a concise set
+such as:
+
+    [480, 768, 1200, 1600]
+
+or an equivalent set justified by the measured layout.
+
+Keep responsive `sizes` accurate for the actual layout. Do not generate widths
+larger than useful display conditions merely because the source permits them.
+
+Retain:
+
+- AVIF preferred format;
+- WebP fallback;
+- lazy loading;
+- existing alt text;
+- existing visual dimensions and layout.
+
+Acceptance:
+
+- a DPR 2 desktop viewport near the normal maximum rendered width can choose a
+  source around 1200 px or larger when appropriate;
+- mobile and DPR 1 clients still receive smaller responsive variants;
+- aspect ratio remains unchanged;
+- page layout remains visually identical.
+
+Recommended logical commit:
+
+    fix(images): improve Tecdet HiDPI responsive variants
+
+### Milestone H3 — Correct Home Automation rendering
+
+Goal: render `home_homeapp` sharply without creating fake detail through build-time
+upscaling.
+
+Because the source is only 1024 px wide, first search the repository for a
+higher-resolution original or equivalent historical source using narrow filename
+and asset-path searches only.
+
+If a genuine higher-resolution source exists:
+
+- replace the working source while preserving provenance/licensing;
+- generate appropriate responsive widths, including an HiDPI-capable desktop
+  variant;
+- retain the same visible composition.
+
+If no higher-resolution source exists:
+
+- keep the 1024 px source as the maximum real variant;
+- constrain the desktop rendered CSS width to approximately 512 px or another
+  measured value that keeps DPR 2 rendering at or below the source width;
+- preserve responsive mobile behavior;
+- do not generate 1200/1600 px derivatives from the 1024 px source merely to
+  satisfy DPR math.
+
+Prefer a section-specific class or wrapper rather than changing global `Picture`
+or `img` behavior.
+
+Acceptance:
+
+- the image is no longer browser-upscaled beyond its useful intrinsic resolution
+  in the normal desktop layout;
+- no new source upscale is introduced;
+- aspect ratio and current design remain unchanged.
+
+Recommended logical commit:
+
+    fix(images): preserve home automation source resolution
+
+### Milestone H4 — Harden asset optimization guidance
+
+Goal: prevent the same optimization mistake from recurring.
+
+Update:
+
+    .agents/skills/asset-optimization/SKILL.md
+
+Add a concise rule equivalent to:
+
+> Responsive image widths must account for both maximum rendered CSS width and
+> target device pixel ratio. For important photographic or screenshot content,
+> provide approximately 2x the maximum expected CSS width when the source
+> resolution permits it. Never upscale a low-resolution source merely to satisfy
+> this rule; constrain rendered size or obtain a better source instead.
+
+If the repository already has asset validation metadata or reporting that can
+cheaply expose source width versus maximum responsive width, document that check.
+Do not add a complex new framework for this patch.
+
+Recommended logical commit:
+
+    docs(agents): account for HiDPI image sizing
+
+## Surprises & Discoveries
+
+- Observation: the first 1440/DPR2 headless screenshot showed Tecdet stretched
+  vertically even though its generated files preserved the source ratio. The
+  existing case-study rule overrode image width without resetting the HTML height
+  presentation hint; a narrowly scoped `height: auto` correction is required.
+  Evidence: `.agent/evidence/hidpi-responsive-image-correction.md`.
+
+- Observation: the affected AVIF files preserve the original image aspect ratio.
+  The visual defect is therefore caused by insufficient responsive resolution or
+  browser upscaling rather than encoder geometry.
+
+- Observation: `home_tecdet` has enough source resolution to solve the issue with
+  additional responsive variants.
+
+- Observation: `home_homeapp` is source-limited at 1024 px and must not be
+  artificially upscaled unless a higher-resolution original is found.
+
+Move resolved discoveries to the history file only if this active plan grows
+unnecessarily.
+
+## Decision Log
+
+- Decision: treat HiDPI sizing as `rendered CSS width × device pixel ratio`, not
+  CSS width alone.
+  Rationale: responsive image selection must supply sufficient physical pixels for
+  Retina/HiDPI rendering.
+  Date: 2026-08-10.
+
+- Decision: do not upscale low-resolution source assets as a substitute for real
+  source detail.
+  Rationale: generated larger files would increase payload without improving
+  fidelity.
+  Date: 2026-08-10.
+
+- Decision: preserve current site design and optimize only the image delivery and
+  maximum rendered width.
+  Rationale: this is a regression correction, not a redesign.
+  Date: 2026-08-10.
+
+## Validation and Acceptance
+
+Tests and builds must be performed only after the implementation is complete, as
+the final stage of this patch. Earlier focused commands are allowed only to resolve
+a concrete uncertainty that blocks implementation.
+
+Final validation should be proportional and focused.
+
+Run:
+
+    npm run license:check
+    npm run check
+    npm run build
+
+Then inspect the generated homepage output and responsive image variants.
+
+Confirm:
+
+- `home_tecdet` has larger generated responsive variants suitable for DPR 2;
+- `home_homeapp` is not rendered beyond the source-resolution budget, unless a
+  verified higher-resolution source replaced it;
+- generated width/height pairs preserve the original aspect ratio;
+- no image is accidentally stretched by CSS;
+- existing AVIF/WebP behavior remains;
+- no unrelated asset payload regression occurs.
+
+Perform one representative visual verification at:
+
+- desktop around 1440 CSS px, preferably DPR 2;
+- mobile around 390 CSS px.
+
+Interactive Browser availability is not required. Use existing headless tooling,
+generated screenshots, or a narrowly scoped human verification if necessary.
+Browser unavailability must not block completion.
+
+If repository policy requires the complete release-boundary matrix because this
+patch is being published immediately, run it only once after the focused
+validation is green.
+
+## Commit Policy
+
+Follow:
+
+    .agents/skills/logical-commits/SKILL.md
+
+Commits must:
+
+- be written in English;
+- follow Conventional Commits;
+- contain one coherent responsibility;
+- be descriptive rather than filename-oriented;
+- avoid WIP/checkpoint commits;
+- preserve unrelated local changes.
+
+Do not run the complete validation matrix before every commit. Validation belongs
+at the final patch/milestone boundary.
+
+## Token and Execution Budget
+
+Keep execution economical:
+
+- read the state file first on resume;
+- inspect only `src/pages/index.astro`, the two source assets, relevant generated
+  variants, and the asset optimization skill;
+- reuse prior production evidence instead of rebuilding repeatedly;
+- avoid scanning all assets again;
+- avoid rereading completed migration/performance plans;
+- record dimensions and decisions once in the evidence file;
+- use concise command output.
+
+Implementation files should remain below approximately 20 KB or 600 lines when
+practical. This patch should not require large new files.
+
+## Risks and Open Questions
+
+- A higher-resolution `home_homeapp` source may not exist in the current source
+  tree. If unavailable, rendered-size constraint is the correct fallback.
+- Excessive responsive widths can undo some payload improvements. Use only widths
+  justified by actual rendered size and DPR.
+- CSS constraints must be scoped so they do not unintentionally alter unrelated
+  `Picture` components.
+- If the visual defect persists after physical-pixel correction, investigate
+  source image quality or browser decoding only then; do not broaden scope
+  preemptively.
+
+## Idempotence and Recovery
+
+All implementation changes are source-only and safe to retry.
+
+Do not edit generated `dist/` output.
+
+Before any push or remote state-changing operation:
+
+    git fetch --prune
+    git status --short
+    git rev-parse HEAD
+
+Never force-update `main` or move an existing release tag.
+
+If a responsive-width change causes unacceptable payload growth, revert only the
+affected `Picture` configuration and retain the recorded measurements.
+
+If a replacement `home_homeapp` source is introduced, preserve the old source in
+Git history; do not delete unrelated historical assets during this patch.
+
+## Outcomes & Retrospective
+
+The focused patch retains the 1024×600 Home Automation source after proving no
+higher-resolution repository version exists, caps its normal rendering at 512 CSS
+px, and preserves its 480/768/1024 candidates. Tecdet now uses
+480/768/1200/1600 AVIF and WebP candidates from the 3366×2092 source, with a
+1600 px fallback ceiling and narrow `height: auto` protection. Generated ratios,
+license checks, Astro check, asset budgets, and representative headless desktop and
+mobile captures pass. The homepage fallback proxy improves from the prior 2.01 MiB
+evidence to 1.63 MiB; no deployment was performed.
+
+## Revision Note
+
+Created as a focused follow-up to the completed post-migration visual and asset
+optimization work. The scope is intentionally limited to the two remaining HiDPI
+image regressions and the reusable guidance needed to prevent recurrence.

--- a/.agent/reports/hidpi-responsive-image-correction-editorial.md
+++ b/.agent/reports/hidpi-responsive-image-correction-editorial.md
@@ -1,0 +1,65 @@
+<!--
+SPDX-FileCopyrightText: 2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: MIT
+-->
+
+# HiDPI responsive image correction editorial report
+
+## Editorial Summary
+
+The homepage's two remaining soft or distorted images now respect both rendered
+CSS width and device pixel ratio without manufacturing detail from a small source.
+
+## Original Plan versus Actual Outcome
+
+The planned candidate and CSS corrections were delivered. Final visual validation
+also found and corrected a narrow Tecdet height-stretching rule.
+
+## What Changed
+
+Tecdet gained 1200 and 1600 px AVIF/WebP candidates and a 1600 px fallback ceiling.
+Home Automation retained its real 1024 px source and gained a 512 CSS px cap.
+Reusable asset guidance now requires CSS-width × DPR planning and forbids upscaling.
+
+## Decisions and Trade-offs
+
+No historical Home Automation source exceeded 1024×600, so constraining display
+size was preferred over larger files with no additional detail. Tecdet's genuine
+3366×2092 source supports the larger candidates.
+
+## Unexpected Problems and Discoveries
+
+The first desktop capture isolated Tecdet distortion to a CSS width override that
+did not reset the HTML height hint. A case-study-specific `height: auto` rule fixed
+the ratio without affecting other `Picture` components.
+
+## Validation and Measurable Results
+
+License and Astro checks pass, all generated ratios are within 0.5 px of source
+ratios after rounding, asset budgets pass, and 1440/DPR2 plus 390 px captures pass.
+The homepage fallback proxy falls from 2.01 MiB to 1.63 MiB.
+
+## Useful Evidence and Examples
+
+See `.agent/evidence/hidpi-responsive-image-correction.md` for dimensions,
+candidate sizes, commands, payload measurements, and temporary screenshot paths.
+
+## Limitations, Remaining Work, and Open Questions
+
+The patch was validated locally and was not deployed. No unrelated images were
+audited or changed.
+
+## Possible Article Angles
+
+Responsive-image quality depends on physical pixels, and honest constraints can
+be better than upscaling when a source master is resolution-limited.
+
+## Suggested Narrative
+
+Start with CSS-width × DPR math, contrast the source-rich and source-limited fixes,
+then show how one visual pass separated encoder quality from CSS distortion.
+
+## Claims Requiring Human Review
+
+Any claim about production rendering after deployment requires a production
+capture; this report covers local production output only.

--- a/.agent/state/hidpi-responsive-image-correction.md
+++ b/.agent/state/hidpi-responsive-image-correction.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: 2026 Amalgam Solucoes em TI Ltda.
+SPDX-License-Identifier: MIT
+-->
+
+# HiDPI responsive image correction state
+
+- Active milestone: complete.
+- Active slice: none; the final documentation commit records closure.
+- Base and branch: `fix/hidpi-responsive-images` at `9788651`, created from the
+  fetched `origin/main` on 2026-08-11.
+- Last logical commit: `b6110f8` (`docs(agents): account for HiDPI image sizing`);
+  implementation is `b9326e5` (`fix(images): correct homepage HiDPI rendering`).
+- Active paths: `src/pages/index.astro`,
+  `.agents/skills/asset-optimization/SKILL.md`, and this plan's support files.
+- Next concrete action: none. If publishing, fetch and recheck remote state before
+  any push or pull-request operation.
+- Focused validation completed: targeted and repository-wide license checks; Astro
+  check; final production build; generated dimensions, markup, candidate, ratio,
+  and asset-budget checks; headless Edge captures at 1440 CSS px/DPR2 and 390 px.
+- Deferred validation: none. Deployment/release checks are outside this focused
+  source patch.
+- Active decisions: no higher-resolution `home_homeapp` source exists in narrow
+  repository history; keep its 1024 px source and cap normal rendering at 512 CSS
+  px. Tecdet's 3366 px source permits 1200/1600 px responsive variants.
+- Blockers: none.
+- Deliberate out of scope: unrelated assets, generated `dist/`, layout redesign,
+  and broader migration/performance work.
+- Resume command: `git status --short --branch && sed -n '1,180p' .agent/state/hidpi-responsive-image-correction.md`.

--- a/.agents/skills/asset-optimization/SKILL.md
+++ b/.agents/skills/asset-optimization/SKILL.md
@@ -19,8 +19,13 @@ the page that consumes each asset.
 3. Preserve historical `src/assets/**` provenance under `REUSE.toml`. Run the
    license-validation skill for new derivatives or moved files.
 4. Prefer Astro `Picture` for responsive AVIF/WebP photographic content, `Image` for
-   optimized local images, and `getImage` for CSS backgrounds. Keep intrinsic sizes,
-   eager-load only the LCP asset, and lazy-load below-fold images.
+   optimized local images, and `getImage` for CSS backgrounds. Size responsive
+   candidates from the maximum rendered CSS width multiplied by the target device
+   pixel ratio; provide approximately 2x coverage for important imagery when the
+   source resolution permits it. Never upscale a low-resolution source to create a
+   fake quality improvement: obtain a better source or constrain the rendered CSS
+   width instead. Keep intrinsic sizes, eager-load only the LCP asset, and lazy-load
+   below-fold images.
 5. Replace large animated GIF delivery with WebM plus MP4 fallback and a compact
    poster. Record deterministic conversion commands; do not add ffmpeg to normal builds.
 6. Complete the coherent slice before final validation. Run `npm run assets:test`,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,17 @@ const wavesBackground = await getImage({ src: waves, width: 1600, format: "webp"
     <div class="container">
       <h2 class="section-title light-title">What is TotalCross?</h2>
       <div class="two-column">
-        <Picture src={homeApp} formats={["avif"]} fallbackFormat="webp" widths={[480, 768, 1024]} sizes="(max-width: 768px) 100vw, 50vw" quality={80} alt="Home automation interface made with TotalCross" loading="lazy" />
+        <Picture
+          src={homeApp}
+          formats={["avif"]}
+          fallbackFormat="webp"
+          widths={[480, 768, 1024]}
+          sizes="(max-width: 544px) calc(100vw - 2.5rem), 512px"
+          quality={80}
+          alt="Home automation interface made with TotalCross"
+          loading="lazy"
+          pictureAttributes={{ class: "home-app-picture" }}
+        />
         <div class="prose">
           <p>TotalCross is an open-source cross-platform SDK developed to make your life easier when creating mobile-grade user experiences for embedded systems.</p>
           <p>All while delivering native performance with a low footprint.</p>
@@ -99,7 +109,17 @@ const wavesBackground = await getImage({ src: waves, width: 1600, format: "webp"
         <p>They rebuilt their system for Linux Arm on Toradex modules and chose TotalCross to develop the GUI.</p>
         <Button href="/traffic-control-system-by-tecdet/" label="Read the case" tone="dark" />
       </div>
-      <Picture src={tecdet} formats={["avif"]} fallbackFormat="webp" widths={[360, 600, 900]} sizes="(max-width: 768px) 100vw, 50vw" quality={80} alt="Tecdet traffic control system" loading="lazy" />
+      <Picture
+        src={tecdet}
+        formats={["avif"]}
+        fallbackFormat="webp"
+        widths={[480, 768, 1200, 1600]}
+        sizes="(max-width: 768px) calc(100vw - 2.5rem), min(42vw, 600px)"
+        width={1600}
+        quality={80}
+        alt="Tecdet traffic control system"
+        loading="lazy"
+      />
     </div>
   </section>
 
@@ -170,8 +190,25 @@ const wavesBackground = await getImage({ src: waves, width: 1600, format: "webp"
     width: 140px;
   }
 
-  .case-study > :global(picture),
+  .two-column > :global(.home-app-picture) {
+    display: block;
+    justify-self: center;
+    max-width: 512px;
+    width: 100%;
+  }
+
+  .two-column > :global(.home-app-picture img) {
+    display: block;
+    height: auto;
+    width: 100%;
+  }
+
+  .case-study > :global(picture) {
+    width: 100%;
+  }
+
   .case-study > :global(picture img) {
+    height: auto;
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary

- Corrects visible softness and stretching affecting home_homeapp and home_tecdet on HiDPI displays while preserving the existing homepage design and responsive behavior.
- Confirms the generated image aspect ratios were already correct; the regression came from insufficient physical-pixel resolution at the rendered CSS size.
- Adds appropriately larger 1200 px and 1600 px responsive variants for Tecdet and restores automatic height handling.
- Keeps Home Automation’s real 1024 px source and caps normal rendering at 512 CSS px to avoid artificial upscaling when no higher-resolution source is available.
- Updates the asset-optimization guidance to size responsive candidates from CSS width × target DPR and to avoid source upscaling.

## Validation

- SPDX and repository-wide license checks
- Astro static checks and production build
- Generated markup, dimensions, candidates, aspect ratios, and asset-budget checks
- Headless desktop validation at 1440 CSS px / DPR 2 and mobile validation at 390 px

The change retains AVIF/WebP delivery, expected aspect ratios, content order, visual design, and mobile stacking.