### PR TITLE
chore(release): prepare v1.0.2

### DIFF
--- a/.agent/evidence/hidpi-responsive-image-correction.md
+++ b/.agent/evidence/hidpi-responsive-image-correction.md
@@ -70,3 +70,28 @@ SPDX-License-Identifier: MIT
 - `b6110f8` — `docs(agents): account for HiDPI image sizing`.
 - Status: implementation and reusable guidance recorded without unrelated files;
   plan/state/evidence/editorial closure follows as its own documentation commit.
+
+## 2026-08-11T02:09:57Z — H5 implementation publication
+
+- Branch HEAD `220f0e6` passed PR #15's required `Build validated Pages artifact`
+  check and merged normally into `main` as `b5fa9e95c70530ebcbc9e8d1526d77e319d7a34a`.
+- Pages run 31451476402 built, validated, uploaded, and deployed that exact merge
+  commit successfully. Production returned HTTPS 200 after deployment.
+- Live desktop DPR 2 measurement selected the 1024 px Home Automation AVIF at
+  512×300 CSS px and the 1200 px Tecdet AVIF near 600×374 CSS px. Narrow responsive
+  measurement and captures preserved landscape ratios and stacking. Favicon,
+  Apple-touch icon, social image, and six footer social links remained available.
+- Limitation: no release tag was authorized during this publication slice.
+
+## 2026-08-11T02:46:41Z — H5 v1.0.2 release candidate
+
+- Revision: working tree based on deployed `main` merge `b5fa9e9`; branch
+  `chore/v1.0.2-release` contains only release metadata and plan closure changes.
+- Metadata: package and lockfile identify `1.0.2`; the dated changelog records the
+  HiDPI correction; release policy accepts absent-as-expected `v1.0.2`.
+- Node 24 release matrix: 17 tests passed; license policy accepted 179/179 files;
+  release and workflow checks passed; Astro checked 54 files with zero diagnostics;
+  18 pages built; asset budgets passed with one unchanged warning; validation found
+  14 routes, zero broken links, valid content/RSS/sitemaps, and excluded drafts.
+- Deferred: PR checks, merged Pages deployment, repeat production proof, annotated
+  tag, and GitHub Release must use the exact final deployed `main` commit.

--- a/.agent/plans/hidpi-responsive-image-correction.md
+++ b/.agent/plans/hidpi-responsive-image-correction.md
@@ -65,6 +65,16 @@ Preserve unrelated local changes.
 - [x] (2026-08-11T01:38:00Z) Recorded final evidence and created logical
       Conventional Commits for implementation and reusable guidance; this plan's
       support files close in the final documentation commit.
+- [x] (2026-08-11T02:09:57Z) Merged PR #15 as `b5fa9e9`, passed required CI,
+      deployed that exact `main` commit through GitHub Pages, and verified live
+      desktop DPR 2 plus narrow responsive image delivery.
+- [x] (2026-08-11T02:46:41Z) Prepared coherent `v1.0.2` package, lockfile,
+      changelog, release-check, and plan metadata; the complete Node 24 release
+      matrix passed once.
+- [x] (2026-08-11T02:48:00Z) Recorded the validated metadata as the single logical
+      `chore(release): prepare v1.0.2` commit.
+- [ ] Publish the release metadata through normal review, verify its exact Pages
+      deployment, then create the annotated tag and GitHub Release.
 
 ## Current Architecture and Scope
 
@@ -242,6 +252,43 @@ Recommended logical commit:
 
     docs(agents): account for HiDPI image sizing
 
+### Milestone H5 — Publish v1.0.2
+
+Goal: publish the verified HiDPI correction as the next SemVer patch release without
+moving an existing tag or tagging an unverified source revision.
+
+Update `package.json`, the lockfile root metadata, `CHANGELOG.md`, and the release
+checker to identify `1.0.2`. Record the production and release evidence in this
+plan's existing support files. Commit the coherent metadata slice as:
+
+    chore(release): prepare v1.0.2
+
+Push `chore/v1.0.2-release`, create a pull request against `main`, inspect its exact
+diff and required checks, and merge only when it is clean and green. The automatic
+operations authorized by the user are the branch push, PR creation, normal merge,
+Pages workflow observation, annotated tag push, and GitHub Release creation.
+
+Immediately before each remote mutation, fetch and recheck `main`, the branch,
+`v1.0.2`, the GitHub Release, and the clean worktree. The effective release tag is
+`v1.0.2`; it and the GitHub Release must point to the exact release-metadata merge
+commit deployed successfully from `main`, not the earlier implementation commit.
+
+If the branch, PR, tag, or release already exists with the expected identity, reuse
+it. If any exists with a different commit or metadata, stop rather than overwrite,
+retag, force-push, or duplicate it. If merge succeeds but deployment fails, fix only
+the concrete failure through another branch and PR, then tag the final verified
+`main` commit. If the tag push succeeds but GitHub Release creation fails, reuse the
+same tag when retrying the release creation.
+
+Acceptance:
+
+- package, lockfile, changelog, and release checker agree on `1.0.2`;
+- the complete release-boundary validation passes once;
+- required PR checks and the Pages workflow pass for the exact merge commit;
+- production still serves the HiDPI correction and basic homepage health;
+- annotated `v1.0.2` and the GitHub Release resolve to that deployed merge commit;
+- unrelated local changes, existing tags, and generated `dist/` remain untouched.
+
 ## Surprises & Discoveries
 
 - Observation: the first 1440/DPR2 headless screenshot showed Tecdet stretched
@@ -282,6 +329,12 @@ unnecessarily.
   Rationale: this is a regression correction, not a redesign.
   Date: 2026-08-10.
 
+- Decision: publish the correction as `v1.0.2` from a dedicated release-metadata
+  branch and tag only its verified `main` merge commit.
+  Rationale: `v1.0.1` is already immutable and repository policy binds releases to
+  dated changelog metadata and the exact deployed production source.
+  Date: 2026-08-10.
+
 ## Validation and Acceptance
 
 Tests and builds must be performed only after the implementation is complete, as
@@ -320,6 +373,21 @@ Browser unavailability must not block completion.
 If repository policy requires the complete release-boundary matrix because this
 patch is being published immediately, run it only once after the focused
 validation is green.
+
+For H5, run the release-boundary matrix once before committing:
+
+    npm test
+    npm run license:check:all
+    npm run release:check
+    npm run workflow:check
+    npm run check
+    npm run build
+    npm run assets:check
+    npm run validate
+
+Then require the normal PR validation and the Pages workflow for the exact merge
+commit. After production verification, confirm `git cat-file -t v1.0.2` reports a
+tag object and both GitHub tag and release resolve to that merge commit.
 
 ## Commit Policy
 
@@ -381,6 +449,12 @@ Before any push or remote state-changing operation:
 
 Never force-update `main` or move an existing release tag.
 
+The release flow is safe to retry. Reuse an expected remote branch, PR, annotated
+tag, or GitHub Release; never overwrite an object with a different identity. A tag
+must not be created until its `main` commit has a successful Pages deployment and
+focused production proof. Keep explicit paths when staging so unrelated local work
+cannot enter the release commit.
+
 If a responsive-width change causes unacceptable payload growth, revert only the
 affected `Picture` configuration and retain the recorded measurements.
 
@@ -396,10 +470,17 @@ px, and preserves its 480/768/1024 candidates. Tecdet now uses
 1600 px fallback ceiling and narrow `height: auto` protection. Generated ratios,
 license checks, Astro check, asset budgets, and representative headless desktop and
 mobile captures pass. The homepage fallback proxy improves from the prior 2.01 MiB
-evidence to 1.63 MiB; no deployment was performed.
+evidence to 1.63 MiB. PR #15 merged as `b5fa9e9`; its required CI, Pages deployment,
+HTTPS health, live responsive candidates, DPR 2 selection, aspect ratios, favicon,
+social icons, and desktop/mobile layout checks passed. The authorized `v1.0.2`
+metadata/tag/Release closure is the remaining milestone.
 
 ## Revision Note
 
 Created as a focused follow-up to the completed post-migration visual and asset
 optimization work. The scope is intentionally limited to the two remaining HiDPI
 image regressions and the reusable guidance needed to prevent recurrence.
+
+Revised on 2026-08-10 after explicit authorization to publish a new release. Added
+H5 so version metadata, concurrency checks, deployed-commit selection, annotated
+tagging, GitHub Release creation, and partial-publication recovery remain resumable.

--- a/.agent/reports/hidpi-responsive-image-correction-editorial.md
+++ b/.agent/reports/hidpi-responsive-image-correction-editorial.md
@@ -13,7 +13,8 @@ CSS width and device pixel ratio without manufacturing detail from a small sourc
 ## Original Plan versus Actual Outcome
 
 The planned candidate and CSS corrections were delivered. Final visual validation
-also found and corrected a narrow Tecdet height-stretching rule.
+also found and corrected a narrow Tecdet height-stretching rule. PR #15 then passed
+review automation, merged normally, and deployed successfully to production.
 
 ## What Changed
 
@@ -37,7 +38,9 @@ the ratio without affecting other `Picture` components.
 
 License and Astro checks pass, all generated ratios are within 0.5 px of source
 ratios after rounding, asset budgets pass, and 1440/DPR2 plus 390 px captures pass.
-The homepage fallback proxy falls from 2.01 MiB to 1.63 MiB.
+The homepage fallback proxy falls from 2.01 MiB to 1.63 MiB. Production selects the
+1024 px Home Automation and 1200 px Tecdet AVIF candidates near their desktop DPR 2
+maximums while preserving ratios and responsive layout.
 
 ## Useful Evidence and Examples
 
@@ -46,8 +49,9 @@ candidate sizes, commands, payload measurements, and temporary screenshot paths.
 
 ## Limitations, Remaining Work, and Open Questions
 
-The patch was validated locally and was not deployed. No unrelated images were
-audited or changed.
+The patch is deployed. Publishing `v1.0.2` requires the authorized metadata PR,
+repeat deployment proof, annotated tag, and GitHub Release. No unrelated images
+were audited or changed.
 
 ## Possible Article Angles
 
@@ -61,5 +65,5 @@ then show how one visual pass separated encoder quality from CSS distortion.
 
 ## Claims Requiring Human Review
 
-Any claim about production rendering after deployment requires a production
-capture; this report covers local production output only.
+No production-rendering claim remains dependent on manual review; HTTPS, live DOM
+measurements, delivered candidates, and headless captures established the result.

--- a/.agent/state/hidpi-responsive-image-correction.md
+++ b/.agent/state/hidpi-responsive-image-correction.md
@@ -5,25 +5,34 @@ SPDX-License-Identifier: MIT
 
 # HiDPI responsive image correction state
 
-- Active milestone: complete.
-- Active slice: none; the final documentation commit records closure.
-- Base and branch: `fix/hidpi-responsive-images` at `9788651`, created from the
-  fetched `origin/main` on 2026-08-11.
-- Last logical commit: `b6110f8` (`docs(agents): account for HiDPI image sizing`);
-  implementation is `b9326e5` (`fix(images): correct homepage HiDPI rendering`).
-- Active paths: `src/pages/index.astro`,
-  `.agents/skills/asset-optimization/SKILL.md`, and this plan's support files.
-- Next concrete action: none. If publishing, fetch and recheck remote state before
-  any push or pull-request operation.
+- Active milestone: H5 — publish the authorized `v1.0.2` patch release.
+- Active slice: validated release metadata is committed; recheck remote refs and
+  publish the branch for normal review.
+- Base and branch: `chore/v1.0.2-release` from fetched `origin/main` at merge
+  `b5fa9e9`, which contains HiDPI branch HEAD `220f0e6`.
+- Last logical commit: `chore(release): prepare v1.0.2`; implementation closure
+  `220f0e6` previously merged through PR #15 as `b5fa9e9`.
+- Active paths: `package.json`, `package-lock.json`, `CHANGELOG.md`,
+  `scripts/check-release.mjs`, and this plan's state/evidence/editorial files.
+- Next concrete action: fetch and recheck `main`, branch, tag, release, and clean
+  worktree; then push `chore/v1.0.2-release` without force and open the PR.
 - Focused validation completed: targeted and repository-wide license checks; Astro
   check; final production build; generated dimensions, markup, candidate, ratio,
   and asset-budget checks; headless Edge captures at 1440 CSS px/DPR2 and 390 px.
-- Deferred validation: none. Deployment/release checks are outside this focused
-  source patch.
+- Production proof: PR #15 CI passed; Pages run 31451476402 deployed `b5fa9e9`;
+  live HTTPS, desktop DPR 2, narrow responsive delivery, ratios, icons, and layout
+  checks passed.
+- Release matrix: Node 24 passed 17 tests; 179/179 license files; release and
+  workflow policy; 54 Astro files with zero diagnostics; 18-page build; asset
+  budgets with one unchanged warning; 14 routes; content, RSS, and sitemaps.
+- Deferred validation: PR checks, exact Pages deployment, repeat production proof,
+  annotated `v1.0.2`, and GitHub Release publication.
 - Active decisions: no higher-resolution `home_homeapp` source exists in narrow
   repository history; keep its 1024 px source and cap normal rendering at 512 CSS
   px. Tecdet's 3366 px source permits 1200/1600 px responsive variants.
+- Release decisions: `v1.0.2` is the next patch; tag only the successfully deployed
+  release-metadata merge commit; stop on conflicting remote branch/tag/release state.
 - Blockers: none.
 - Deliberate out of scope: unrelated assets, generated `dist/`, layout redesign,
   and broader migration/performance work.
-- Resume command: `git status --short --branch && sed -n '1,180p' .agent/state/hidpi-responsive-image-correction.md`.
+- Resume command: `sed -n '1,180p' .agent/state/hidpi-responsive-image-correction.md && git status --short --branch`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ capability and compatibility releases.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-08-10
+
+### Fixed
+
+- Corrected Home Automation and Tecdet homepage rendering on HiDPI displays while
+  preserving their source aspect ratios and the existing responsive design.
+- Added 1200 px and 1600 px Tecdet responsive variants from its high-resolution
+  source and constrained Home Automation to its real 1024 px source budget instead
+  of artificially upscaling it.
+
 ## [1.0.1] - 2026-08-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "totalcross-site",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "totalcross-site",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "typeface-merriweather": "0.0.72",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "totalcross-site",
   "private": true,
   "description": "Source for the TotalCross project website at totalcross.com.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "TotalCross",
   "bugs": {
     "url": "https://github.com/TotalCross/totalcross.github.io/issues"

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -20,7 +20,7 @@ function requireValue(condition, message) {
 
 requireValue(packageJson.name === "totalcross-site", "Package name is not the repository identity");
 requireValue(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageJson.version), "Package version is not SemVer");
-requireValue(packageJson.version === "1.0.1", "Post-migration correction release must be version 1.0.1");
+requireValue(packageJson.version === "1.0.2", "HiDPI correction release must be version 1.0.2");
 requireValue(packageJson.private === true, "Website package must remain private");
 requireValue(packageJson.homepage === "https://totalcross.com", "Package homepage is not production");
 requireValue(packageJson.repository?.url === expectedRepository, "Package repository metadata is incorrect");


### PR DESCRIPTION
## Summary

- Sets the site package and lockfile version to 1.0.2.
- Adds the dated v1.0.2 changelog entry for the HiDPI Home Automation and Tecdet correction.
- Updates the release consistency check for the new patch version.
- Records the verified PR #15 deployment and the safe annotated-tag and GitHub Release workflow.

## Validation

- Node 24: 17 tests passed
- License policy: 179/179 files compliant
- Release and workflow checks passed
- Astro check: 54 files, zero diagnostics
- Production build: 18 pages
- Asset budgets passed with one unchanged warning
- Route/content validation: 14 routes, zero broken links, valid RSS and sitemaps

After merge, v1.0.2 will be tagged only on the exact main commit that passes the GitHub Pages deployment and production verification.